### PR TITLE
add refresh to maintenance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Welcome to the 'Apex Legends Tracker' changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+### Added
+- Added a 15-second refresh to the maintenance page to check to see if the site is ready, and if it is, reload it.
 
 ## [0.8.4]
 More ranked progression work

--- a/flask_site/templates/503.html
+++ b/flask_site/templates/503.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+    <meta http-equiv="refresh" content="15; url=/">
     <title>Performing Maintenance</title>
-    <style type="text/css">
+    <style>
         body { text-align: center; padding: 150px; }
         h1 { font-size: 40px; }
         body { font: 20px Helvetica, sans-serif; color: #333; }


### PR DESCRIPTION
### Added
- Added a 15-second refresh to the maintenance page to check to see if the site is ready, and if it is, reload it.

Resolves #131 