### PR TITLE
Fixed issue on Battlepass page with max bar running over the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Welcome to the 'Apex Legends Tracker' changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2021-07-09
+### Fixed
+- Fixed battlepass issue where the bar ran over the end if the player hit max battlepass
+- Resolves #204
+
 ## [1.4.2] - 2021-07-09
 ### Fixed
 - Fixed an issue where the new tooltip did not display correctly on an iphone

--- a/flask_site/templates/battlepass.html
+++ b/flask_site/templates/battlepass.html
@@ -16,6 +16,9 @@
         {% for player in view_controller.players_sorted_by_key(key='name') %}
             {% if player.battlepass_level > -1 %}
                 {% set battlepass_level = player['battlepass_level'] %}
+                {% if battlepass_level > max_battlepass %}
+                    {% set max_battlepass = battlepass_level %}
+                {% endif %}
                 {% set percent_to_goal = (player['battlepass_level'] / goal_level * 100) %}
                 {% set delta_from_goal = battlepass_level - goal_level  %}
                 {% set plus_sign = "" %}


### PR DESCRIPTION
Resolves #204
If a user has reached 100% — the bar runs over